### PR TITLE
Minor UI improvements based on 61A sessions used for C88C sessions

### DIFF
--- a/src/snapshots-app/app/views/layouts/login.html.erb
+++ b/src/snapshots-app/app/views/layouts/login.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Login</title>
+    <title>Assignment Snapshots</title>
     <%= csrf_meta_tags %>
     <%= javascript_pack_tag 'client-bundle' %>
     <%= stylesheet_pack_tag 'client-bundle' %>

--- a/src/snapshots-app/client/bundles/components/common/Footer.jsx
+++ b/src/snapshots-app/client/bundles/components/common/Footer.jsx
@@ -6,7 +6,7 @@ function Footer() {
   return (
     <div
       style={{
-        position: "fixed",
+        // position: "fixed",
         bottom: 0,
         width: "100%",
         color: "#808080",

--- a/src/snapshots-app/client/bundles/components/submission/FileViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/FileViewer.jsx
@@ -28,6 +28,7 @@ function FileViewer({ code, language, lightMode, lintErrors }) {
 
   return (
     <div>
+      <div style={{ paddingBottom: '1rem' }}>There are {lintErrors.length} lint errors in this file.</div>
       <Paper elevation={3} sx={{ padding: 2 }}>
         <Typography
           variant="body2"

--- a/src/snapshots-app/client/bundles/components/submission/Timeline.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/Timeline.jsx
@@ -9,6 +9,12 @@ import { Tooltip } from "@mui/material";
 import InfoTooltip from "../common/InfoTooltip";
 
 function TimelineButton({ backup, selected, index, handleBackupSelect }) {
+  function getQuestionsWorkedOn() {
+    return backup.question_display_names.join(" ");
+
+
+  }
+
   function getNumPassedTests() {
     if (backup.unlock) {
       return backup.unlock_message_cases
@@ -44,21 +50,23 @@ function TimelineButton({ backup, selected, index, handleBackupSelect }) {
   }
 
   function getTooltipTitle() {
+    const questions = getQuestionsWorkedOn();
+
     if (backup.unlock) {
       if (numFailedTests === 0) {
         if (numPassedTests > 0) {
-          return `All ${numPassedTests} unlocking tests passed`;
+          return `Worked on: ${questions}. All ${numPassedTests} unlocking tests passed`;
         } else {
-          return `Ran unlocking command but no test data`;
+          return `Ran unlocking command for ${questions} but there was no test data`;
         }
       } else {
-        return `${numPassedTests} unlocking tests passed, ${numFailedTests} unlocking tests failed`;
+        return `Worked on: ${questions}. ${numPassedTests} unlocking tests passed, ${numFailedTests} unlocking tests failed`;
       }
     } else {
       if (numFailedTests === 0 && numLockedTests === 0) {
-        return `All ${numPassedTests} coding tests passed`;
+        return `Worked on: ${questions}. All ${numPassedTests} coding tests passed`;
       } else {
-        return `${numPassedTests} coding tests passed, ${numFailedTests} coding tests failed, ${numLockedTests} coding tests locked`;
+        return `Worked on: ${questions}. ${numPassedTests} coding tests passed, ${numFailedTests} coding tests failed, ${numLockedTests} coding tests locked`;
       }
     }
   }

--- a/src/snapshots-app/client/bundles/layouts/SubmissionLayout.jsx
+++ b/src/snapshots-app/client/bundles/layouts/SubmissionLayout.jsx
@@ -34,12 +34,14 @@ const LeftSidebar = styled("aside")(({ theme }) => ({
   borderRight: `1px solid ${theme.palette.divider}`,
   padding: theme.spacing(2),
   minWidth: 0,
+  overflowY: "auto",
 }));
 
 const MainContent = styled("main")(({ theme }) => ({
   flex: "5 0 0",
   padding: theme.spacing(2),
   minWidth: 0,
+  overflowY: "auto",
 }));
 
 const RightSidebar = styled("aside")(({ theme }) => ({
@@ -47,11 +49,13 @@ const RightSidebar = styled("aside")(({ theme }) => ({
   borderLeft: `1px solid ${theme.palette.divider}`,
   padding: theme.spacing(2),
   minWidth: 0,
+  overflowY: "auto",
 }));
 
 const ContentWrapper = styled(Box)({
   display: "flex",
   flexGrow: 1,
+  maxHeight: "100vh",
 });
 
 function SubmissionLayout() {
@@ -99,7 +103,7 @@ function SubmissionLayout() {
         return response.json();
       })
       .then((responseData) => {
-        setBackups(responseData.backups);
+        setBackups(responseData.backups.toReversed());
         setSelectedBackup(0);
         setFiles(responseData.assignment_file_names);
         setFile(responseData.assignment_file_names[0]);
@@ -449,6 +453,11 @@ function SubmissionLayout() {
                     >
                       <DifferenceIcon />
                     </IconButton>
+
+                    {selectedBackup === 0 ||
+                        code === "" ||
+                        prevFileContents === "" ||
+                        prevFileContents === code ? "No diff available" : "Diff available"}
                   </Tooltip>
                 )}
 


### PR DESCRIPTION
- Fix website title
- Have separate scroll bars for the `SubmissionLayout`'s `LeftSidebar`, `FileViewer`, and `RightSidebar` sections
- Make `Footer` not fixed position so that scrolling in different sections of the `SubmissionLayout` works properly (otherwise the footer covers the bottom of the left sidebar, file viewer, and right sidebar because it has a higher z-index)
- Tell user how many lint errors exist at the top of the file viewer
- For each `TimelineButton`, display the problem the student was working on in the `Tooltip`
- Reverse order of `Timeline` so that the most recent backup is first
- Make it clearer what the diff button is by displaying the text "Diff available" and "No diff available" next to the diff icon