### PR TITLE
Retrieve last backup instead of first backup in Style Tab

### DIFF
--- a/src/snapshots-app/client/bundles/components/submission/tabs/style/StyleTab.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/style/StyleTab.jsx
@@ -99,7 +99,7 @@ function StyleTab() {
     const codeQueryParams = new URLSearchParams();
     codeQueryParams.append(
       "object_key",
-      `${backups[backups.length - 1].file_contents_location}/${file}`,
+      `${backups[0].file_contents_location}/${file}`,
     );
 
     fetch(`/api/files?${codeQueryParams}`)
@@ -112,7 +112,7 @@ function StyleTab() {
     const lintErrorsQueryParams = new URLSearchParams();
     lintErrorsQueryParams.append(
       "file_contents_location",
-      `${backups[backups.length - 1].file_contents_location}/${file}`,
+      `${backups[0].file_contents_location}/${file}`,
     );
 
     fetch(`/api/lint_errors?${lintErrorsQueryParams}`)


### PR DESCRIPTION
Fix bug where I accidentally retrieved the first backup instead of the last one (since the `backups` atom is reversed).