### PR TITLE
Implement unified, collapsed diff by default and jump to problem line

### DIFF
--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
@@ -4,11 +4,15 @@ import Editor from "@monaco-editor/react";
 
 import "./FileViewer.css";
 
-function BasicFileViewer({ code, language, lightMode }) {
+function BasicFileViewer({ code, language, lightMode, editorRef }) {
+
 
   return (
     <>
       <Editor
+      onMount={(editor) => {
+    editorRef.current = editor;
+  }}
         defaultLanguage={language}
         defaultValue={code}
         theme={lightMode ? "light" : "vs-dark"}

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
@@ -5,14 +5,12 @@ import Editor from "@monaco-editor/react";
 import "./FileViewer.css";
 
 function BasicFileViewer({ code, language, lightMode, editorRef }) {
-
-
   return (
     <>
       <Editor
-      onMount={(editor) => {
-    editorRef.current = editor;
-  }}
+        onMount={(editor) => {
+          editorRef.current = editor;
+        }}
         defaultLanguage={language}
         defaultValue={code}
         theme={lightMode ? "light" : "vs-dark"}

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/BasicFileViewer.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import Editor from "@monaco-editor/react";
+
+import "./FileViewer.css";
+
+function BasicFileViewer({ code, language, lightMode }) {
+
+  return (
+    <>
+      <Editor
+        defaultLanguage={language}
+        defaultValue={code}
+        theme={lightMode ? "light" : "vs-dark"}
+        options={{
+          renderValidationDecorations: "on",
+          domReadOnly: true,
+          readOnly: true,
+          renderLineHighlight: "all",
+          renderWhitespace: "all",
+          rulers: [80],
+          scrollBeyondLastLine: false,
+        }}
+      />
+    </>
+  );
+}
+
+export default BasicFileViewer;

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
@@ -23,7 +23,6 @@ function DiffViewer({
   lightMode = false,
   renderSideBySide = false,
 }) {
-
   const onDiffEditorMount = (editor, monaco) => {
     editorRef.current = editor;
 
@@ -95,13 +94,13 @@ function DiffViewer({
           scrollBeyondLastLine: false,
           renderSideBySide: renderSideBySide,
           // Enable the auto-collapse feature
-    hideUnchangedRegions: {
-      enabled: true,
-      contextLineCount: 5,      // Lines of unchanged code to show around a diff
-      minimumLineCount: 3,      // Minimum unchanged lines required to trigger a collapse
-      // TODO this isn't working properly
-      revealLineCount: 20,      // How many lines to reveal when clicking the "expand" button
-    },
+          hideUnchangedRegions: {
+            enabled: true,
+            contextLineCount: 5, // Lines of unchanged code to show around a diff
+            minimumLineCount: 3, // Minimum unchanged lines required to trigger a collapse
+            // TODO this isn't working properly
+            revealLineCount: 20, // How many lines to reveal when clicking the "expand" button
+          },
         }}
       />
     </>

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -17,12 +17,12 @@ import "@git-diff-view/react/styles/diff-view.css";
 function DiffViewer({
   open,
   onClose,
+  editorRef,
   prevFileContents,
   currentFileContents,
   lightMode = false,
   renderSideBySide = false,
 }) {
-  const editorRef = useRef(null);
 
   const onDiffEditorMount = (editor, monaco) => {
     editorRef.current = editor;

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/DiffViewer.jsx
@@ -13,7 +13,15 @@ import { DiffEditor } from "@monaco-editor/react";
 // TODO I have been accidentally relying on this import for styling the entire website
 import "@git-diff-view/react/styles/diff-view.css";
 
-function DiffViewer({ open, onClose, prevFileContents, currentFileContents }) {
+// TODO refactor properly
+function DiffViewer({
+  open,
+  onClose,
+  prevFileContents,
+  currentFileContents,
+  lightMode = false,
+  renderSideBySide = false,
+}) {
   const editorRef = useRef(null);
 
   const onDiffEditorMount = (editor, monaco) => {
@@ -34,58 +42,71 @@ function DiffViewer({ open, onClose, prevFileContents, currentFileContents }) {
   };
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      aria-labelledby="diff-viewer-dialog-title"
-      aria-describedby="diff-viewer-dialog-description"
-      maxWidth="xl"
-      fullWidth
-    >
-      <DialogTitle id="diff-viewer-dialog-title">Diff Viewer</DialogTitle>
-      <DialogContent>
-        <ButtonGroup
-          sx={{
-            marginBottom: "1rem",
-          }}
+    // <Dialog
+    //   open={open}
+    //   onClose={onClose}
+    //   aria-labelledby="diff-viewer-dialog-title"
+    //   aria-describedby="diff-viewer-dialog-description"
+    //   maxWidth="xl"
+    //   fullWidth
+    // >
+    //   <DialogTitle id="diff-viewer-dialog-title">Diff Viewer</DialogTitle>
+    //   <DialogContent>
+    <>
+      <ButtonGroup
+        sx={{
+          marginBottom: "1rem",
+          position: "sticky",
+        }}
+      >
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<ArrowUpwardIcon />}
+          onClick={goToPreviousDiff}
         >
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<ArrowUpwardIcon />}
-            onClick={goToPreviousDiff}
-          >
-            Previous Change
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            endIcon={<ArrowDownwardIcon />}
-            onClick={goToNextDiff}
-          >
-            Next Change
-          </Button>
-        </ButtonGroup>
-        <DiffEditor
-          height="100vh"
-          original={prevFileContents}
-          modified={currentFileContents}
-          language="python"
-          onMount={onDiffEditorMount}
-          // https://github.com/suren-atoyan/monaco-react/issues/647#issuecomment-2897027817
-          keepCurrentOriginalModel={true}
-          keepCurrentModifiedModel={true}
-          options={{
-            readOnly: true,
-            domReadOnly: true,
-            renderLineHighlight: "all",
-            renderWhitespace: "all",
-            rulers: [80],
-            scrollBeyondLastLine: false,
-          }}
-        />
-      </DialogContent>
-    </Dialog>
+          Previous Change
+        </Button>
+        <Button
+          size="small"
+          variant="outlined"
+          endIcon={<ArrowDownwardIcon />}
+          onClick={goToNextDiff}
+        >
+          Next Change
+        </Button>
+      </ButtonGroup>
+      <DiffEditor
+        height="100vh"
+        original={prevFileContents}
+        modified={currentFileContents}
+        language="python"
+        theme={lightMode ? "light" : "vs-dark"}
+        onMount={onDiffEditorMount}
+        // https://github.com/suren-atoyan/monaco-react/issues/647#issuecomment-2897027817
+        keepCurrentOriginalModel={true}
+        keepCurrentModifiedModel={true}
+        options={{
+          readOnly: true,
+          domReadOnly: true,
+          renderLineHighlight: "all",
+          renderWhitespace: "all",
+          rulers: [80],
+          scrollBeyondLastLine: false,
+          renderSideBySide: renderSideBySide,
+          // Enable the auto-collapse feature
+    hideUnchangedRegions: {
+      enabled: true,
+      contextLineCount: 5,      // Lines of unchanged code to show around a diff
+      minimumLineCount: 3,      // Minimum unchanged lines required to trigger a collapse
+      // TODO this isn't working properly
+      revealLineCount: 20,      // How many lines to reveal when clicking the "expand" button
+    },
+        }}
+      />
+    </>
+    //   {/* </DialogContent>
+    // </Dialog> */}
   );
 }
 

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/Graphs.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/Graphs.jsx
@@ -6,9 +6,8 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { Tooltip } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
-import { Link } from '@mui/material';
-import { List, ListItem } from '@mui/material';
-
+import { Link } from "@mui/material";
+import { List, ListItem } from "@mui/material";
 
 function LinearProgressWithLabel(props) {
   return (
@@ -53,14 +52,14 @@ const ProblemJumpLink = ({ lineNumber, editorRef, label }) => {
       variant="body2"
       onClick={handleJump}
       sx={{
-        textAlign: 'left',
-        verticalAlign: 'baseline',
-        textDecoration: 'none',
-        '&:hover': {
-          textDecoration: 'underline',
+        textAlign: "left",
+        verticalAlign: "baseline",
+        textDecoration: "none",
+        "&:hover": {
+          textDecoration: "underline",
         },
-        cursor: 'pointer',
-        color: 'primary.main',
+        cursor: "pointer",
+        color: "primary.main",
         fontWeight: 500,
       }}
     >
@@ -68,7 +67,6 @@ const ProblemJumpLink = ({ lineNumber, editorRef, label }) => {
     </Link>
   );
 };
-
 
 function AssignmentProblems({
   history,
@@ -115,59 +113,70 @@ function AssignmentProblems({
     return (numSolved / allProblemDisplayNames.length) * 100;
   }
 
-
   // TODO span styling and improve accessibility?
   const problems = allProblemDisplayNames.map((problemDisplayName) => {
     const lines = problemLines[problemDisplayName];
 
     if (problemLines[problemDisplayName].length === 0) {
       return (
-      <Box key={problemDisplayName} sx={{ display: 'flex', alignItems: 'center', my: 0.5 }}>
-        {getIcon(problemDisplayName)}
-        <Typography variant="body2" sx={{ ml: 1, color: 'text.disabled' }}>
-          {problemDisplayName} (Not found)
-        </Typography>
-      </Box>
-    );
+        <Box
+          key={problemDisplayName}
+          sx={{ display: "flex", alignItems: "center", my: 0.5 }}
+        >
+          {getIcon(problemDisplayName)}
+          <Typography variant="body2" sx={{ ml: 1, color: "text.disabled" }}>
+            {problemDisplayName} (Not found)
+          </Typography>
+        </Box>
+      );
     } else if (problemLines[problemDisplayName].length === 1) {
       return (
-      <Box key={problemDisplayName} sx={{ display: 'flex', alignItems: 'center', my: 0.5 }}>
-        {getIcon(problemDisplayName)}
-        <Box sx={{ ml: 1 }}>
-          <ProblemJumpLink
-            lineNumber={lines[0]}
-            editorRef={editorRef}
-            label={problemDisplayName}
-          />
+        <Box
+          key={problemDisplayName}
+          sx={{ display: "flex", alignItems: "center", my: 0.5 }}
+        >
+          {getIcon(problemDisplayName)}
+          <Box sx={{ ml: 1 }}>
+            <ProblemJumpLink
+              lineNumber={lines[0]}
+              editorRef={editorRef}
+              label={problemDisplayName}
+            />
+          </Box>
         </Box>
-      </Box>
-    );
+      );
     } else {
       return (
-    <Box key={problemDisplayName} sx={{ my: 1 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        {getIcon(problemDisplayName)}
-        <Typography variant="body2" sx={{ ml: 1 }}>
-          {problemDisplayName}
-        </Typography>
-      </Box>
-      <Box sx={{ pl: 4, display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
-
-        <List sx={{ listStyleType: 'disc', pl: '1rem' }}>
-        {lines.map((lineNumber) => (
-          <ListItem disablePadding sx={{ display: 'list-item' }}>
-          <ProblemJumpLink
-            key={`${problemDisplayName}-${lineNumber}`}
-            lineNumber={lineNumber}
-            editorRef={editorRef}
-            label={`Line ${lineNumber}`}
-          />
-          </ListItem>
-        ))}
-        </List>
-      </Box>
-    </Box>
-  );
+        <Box key={problemDisplayName} sx={{ my: 1 }}>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            {getIcon(problemDisplayName)}
+            <Typography variant="body2" sx={{ ml: 1 }}>
+              {problemDisplayName}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              pl: 4,
+              display: "flex",
+              flexDirection: "column",
+              flexWrap: "wrap",
+            }}
+          >
+            <List sx={{ listStyleType: "disc", pl: "1rem" }}>
+              {lines.map((lineNumber) => (
+                <ListItem disablePadding sx={{ display: "list-item" }}>
+                  <ProblemJumpLink
+                    key={`${problemDisplayName}-${lineNumber}`}
+                    lineNumber={lineNumber}
+                    editorRef={editorRef}
+                    label={`Line ${lineNumber}`}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        </Box>
+      );
     }
   });
 

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/Graphs.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/Graphs.jsx
@@ -6,6 +6,9 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import { Tooltip } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
+import { Link } from '@mui/material';
+import { List, ListItem } from '@mui/material';
+
 
 function LinearProgressWithLabel(props) {
   return (
@@ -27,7 +30,68 @@ function LinearProgressWithLabel(props) {
   );
 }
 
-function AssignmentProblems({ history, allProblemDisplayNames, numSolved }) {
+const ProblemJumpLink = ({ lineNumber, editorRef, label }) => {
+  const handleJump = (event) => {
+    // Prevent default link behavior if necessary
+    event.preventDefault();
+
+    const editorInstance = editorRef.current;
+    if (!editorInstance) return;
+
+    const targetEditor = editorInstance.getModifiedEditor
+      ? editorInstance.getModifiedEditor()
+      : editorInstance;
+
+    targetEditor.revealLineInCenter(lineNumber);
+    targetEditor.setPosition({ lineNumber: lineNumber, column: 1 });
+    targetEditor.focus();
+  };
+
+  return (
+    <Link
+      component="button"
+      variant="body2"
+      onClick={handleJump}
+      sx={{
+        textAlign: 'left',
+        verticalAlign: 'baseline',
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'underline',
+        },
+        cursor: 'pointer',
+        color: 'primary.main',
+        fontWeight: 500,
+      }}
+    >
+      {label || `Line ${lineNumber}`}
+    </Link>
+  );
+};
+
+
+function AssignmentProblems({
+  history,
+  allProblemDisplayNames,
+  numSolved,
+  editorRef,
+  problemLines,
+}) {
+  function goToLine(lineNumber) {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    // 1. Check if it's a Diff Editor (has getModifiedEditor method)
+    // 2. Otherwise treat as a standard editor
+    const targetEditor = editor.getModifiedEditor
+      ? editor.getModifiedEditor()
+      : editor;
+
+    targetEditor.revealLineInCenter(lineNumber);
+    targetEditor.setPosition({ lineNumber: lineNumber, column: 1 });
+    targetEditor.focus();
+  }
+
   function getIcon(problemDisplayName) {
     const problemData = history.find(
       (p) => p.display_name === problemDisplayName,
@@ -51,11 +115,61 @@ function AssignmentProblems({ history, allProblemDisplayNames, numSolved }) {
     return (numSolved / allProblemDisplayNames.length) * 100;
   }
 
-  const problems = allProblemDisplayNames.map((problemDisplayName) => (
-    <div>
-      {getIcon(problemDisplayName)} {problemDisplayName}
-    </div>
-  ));
+
+  // TODO span styling and improve accessibility?
+  const problems = allProblemDisplayNames.map((problemDisplayName) => {
+    const lines = problemLines[problemDisplayName];
+
+    if (problemLines[problemDisplayName].length === 0) {
+      return (
+      <Box key={problemDisplayName} sx={{ display: 'flex', alignItems: 'center', my: 0.5 }}>
+        {getIcon(problemDisplayName)}
+        <Typography variant="body2" sx={{ ml: 1, color: 'text.disabled' }}>
+          {problemDisplayName} (Not found)
+        </Typography>
+      </Box>
+    );
+    } else if (problemLines[problemDisplayName].length === 1) {
+      return (
+      <Box key={problemDisplayName} sx={{ display: 'flex', alignItems: 'center', my: 0.5 }}>
+        {getIcon(problemDisplayName)}
+        <Box sx={{ ml: 1 }}>
+          <ProblemJumpLink
+            lineNumber={lines[0]}
+            editorRef={editorRef}
+            label={problemDisplayName}
+          />
+        </Box>
+      </Box>
+    );
+    } else {
+      return (
+    <Box key={problemDisplayName} sx={{ my: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        {getIcon(problemDisplayName)}
+        <Typography variant="body2" sx={{ ml: 1 }}>
+          {problemDisplayName}
+        </Typography>
+      </Box>
+      <Box sx={{ pl: 4, display: 'flex', flexDirection: 'column', flexWrap: 'wrap' }}>
+
+        <List sx={{ listStyleType: 'disc', pl: '1rem' }}>
+        {lines.map((lineNumber) => (
+          <ListItem disablePadding sx={{ display: 'list-item' }}>
+          <ProblemJumpLink
+            key={`${problemDisplayName}-${lineNumber}`}
+            lineNumber={lineNumber}
+            editorRef={editorRef}
+            label={`Line ${lineNumber}`}
+          />
+          </ListItem>
+        ))}
+        </List>
+      </Box>
+    </Box>
+  );
+    }
+  });
 
   return (
     <div style={{ paddingTop: "1rem", paddingBottom: "1rem" }}>
@@ -71,6 +185,8 @@ function Graphs({
   currBackupHistory,
   allProblemDisplayNames,
   selectedBackup,
+  problemLines,
+  editorRef,
 }) {
   return (
     <div>
@@ -79,6 +195,8 @@ function Graphs({
         history={currBackupHistory}
         allProblemDisplayNames={allProblemDisplayNames}
         numSolved={numQuestionsSolved[selectedBackup]}
+        problemLines={problemLines}
+        editorRef={editorRef}
       />
     </div>
   );

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/TimelineTab.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/TimelineTab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { styled } from "@mui/material/styles";
 import Toolbar from "@mui/material/Toolbar";
 import Box from "@mui/material/Box";
@@ -90,6 +90,8 @@ function TimelineTab() {
 
   const routeParams = useParams();
   const navigate = useNavigate();
+
+  const editorRef = useRef(null);
 
   // Fetch backups
   React.useEffect(() => {
@@ -413,6 +415,43 @@ function TimelineTab() {
     return null;
   }
 
+  function goToLine(lineNumber) {
+    if (editorRef.current) {
+      // Centers the line in the viewport
+      editorRef.current.revealLineInCenter(lineNumber);
+
+      // Moves the cursor to that line
+      editorRef.current.setPosition({ lineNumber: lineNumber, column: 1 });
+
+      // Focuses the editor
+      editorRef.current.focus();
+    }
+  }
+
+  function getProblemLines(code, problemNames) {
+    const result = {};
+    problemNames.forEach((name) => {
+      result[name] = [];
+    });
+
+    const lines = code.split("\n");
+
+    lines.forEach((lineText, index) => {
+      const trimmedLine = lineText.trim();
+
+      if (trimmedLine.startsWith("# BEGIN ")) {
+        const problemName = trimmedLine.replace("# BEGIN ", "").trim();
+
+        // If this name is in our target list, add the line number (1-indexed)
+        if (result.hasOwnProperty(problemName)) {
+          result[problemName].push(index + 1);
+        }
+      }
+    });
+
+    return result;
+  }
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
       {backups.length === 0 ? (
@@ -534,15 +573,22 @@ function TimelineTab() {
             {code === "" ? (
               <CircularProgress />
             ) : (
-              <div style={{ paddingLeft: "1rem", paddingRight: "1rem", height: "100%" }}>
+              <div
+                style={{
+                  paddingLeft: "1rem",
+                  paddingRight: "1rem",
+                  height: "100%",
+                }}
+              >
                 {selectedBackup === 0 ||
                 code === "" ||
                 prevFileContents === "" ||
                 prevFileContents === code ? (
                   <BasicFileViewer
                     code={code}
-                    language={"python"}
+                    language={getLanguage(file)}
                     lightMode={lightMode}
+                    editorRef={editorRef}
                   />
                 ) : (
                   <DiffViewer
@@ -553,6 +599,7 @@ function TimelineTab() {
                     selectedFile={file}
                     prevFileContents={prevFileContents}
                     lightMode={lightMode}
+                    editorRef={editorRef}
                   />
                 )}
               </div>
@@ -581,6 +628,8 @@ function TimelineTab() {
                 currBackupHistory={backups[selectedBackup].history}
                 allProblemDisplayNames={allProblemDisplayNames}
                 selectedBackup={selectedBackup}
+                problemLines={getProblemLines(code, allProblemDisplayNames)}
+                editorRef={editorRef}
               />
             )}
           </RightSidebar>

--- a/src/snapshots-app/client/bundles/components/submission/tabs/timeline/TimelineTab.jsx
+++ b/src/snapshots-app/client/bundles/components/submission/tabs/timeline/TimelineTab.jsx
@@ -19,6 +19,7 @@ import { FormControl, InputLabel } from "@mui/material";
 import DifferenceIcon from "@mui/icons-material/Difference";
 
 import FileViewer from "./FileViewer";
+import BasicFileViewer from "./BasicFileViewer";
 import Graphs from "./Graphs";
 import Timeline from "./Timeline";
 import AutograderOutputDialog from "./AutograderOutputDialog";
@@ -26,6 +27,7 @@ import UnlockingTestOutputDialog from "./UnlockingTestOutputDialog";
 import DiffViewer from "./DiffViewer";
 import InfoTooltip from "../../../common/InfoTooltip";
 import { backupsAtom } from "../../../../state/atoms";
+import { Editor } from "@monaco-editor/react";
 
 // TODO minWidth: 0 prevent main content from stretching out to sidebars, but this seems rather hacky?
 
@@ -428,11 +430,12 @@ function TimelineTab() {
           {/* TODO make width more responsive */}
           <MainContent>
             {/* Main Content Area */}
+            {/* TODO make scrolling less awkward */}
             <div
               style={{
-                position: "sticky",
-                top: -20,
-                zIndex: 10,
+                // position: "sticky",
+                // top: -20,
+                // zIndex: 10,
                 background: "white",
                 paddingBottom: "1rem",
                 marginBottom: "1rem",
@@ -467,7 +470,7 @@ function TimelineTab() {
                   ></FormControlLabel>
                 </FormGroup>
 
-                {selectedBackup !== 0 &&
+                {/* {selectedBackup !== 0 &&
                 code === "" &&
                 prevFileContents === "" ? (
                   <CircularProgress />
@@ -495,7 +498,7 @@ function TimelineTab() {
                       ? "No diff available"
                       : "Diff available"}
                   </Tooltip>
-                )}
+                )} */}
 
                 <Tooltip title="Copy code">
                   <IconButton
@@ -531,17 +534,39 @@ function TimelineTab() {
             {code === "" ? (
               <CircularProgress />
             ) : (
-              <FileViewer
-                code={code}
-                language={getLanguage(file)}
-                lightMode={lightMode}
-                lintErrors={lintErrors}
-                // NOTE: This is needed so that the FileViewer component
-                // re-mounts after DiffViewer dialog closes, otherwise
-                // error occurs because Monaco editor ref gets disposed
-                // when DiffViewer dialog opens
-                key={`${file}-${diffViewerOpen}`}
-              />
+              <div style={{ paddingLeft: "1rem", paddingRight: "1rem", height: "100%" }}>
+                {selectedBackup === 0 ||
+                code === "" ||
+                prevFileContents === "" ||
+                prevFileContents === code ? (
+                  <BasicFileViewer
+                    code={code}
+                    language={"python"}
+                    lightMode={lightMode}
+                  />
+                ) : (
+                  <DiffViewer
+                    open={true}
+                    onClose={() => setDiffViewerOpen(false)}
+                    prevBackup={backups[selectedBackup - 1]}
+                    currentFileContents={code}
+                    selectedFile={file}
+                    prevFileContents={prevFileContents}
+                    lightMode={lightMode}
+                  />
+                )}
+              </div>
+              // <FileViewer
+              //   code={code}
+              //   language={getLanguage(file)}
+              //   lightMode={lightMode}
+              //   lintErrors={lintErrors}
+              //   // NOTE: This is needed so that the FileViewer component
+              //   // re-mounts after DiffViewer dialog closes, otherwise
+              //   // error occurs because Monaco editor ref gets disposed
+              //   // when DiffViewer dialog opens
+              //   key={`${file}-${diffViewerOpen}`}
+              // />
             )}
 
             <Toolbar />
@@ -571,14 +596,14 @@ function TimelineTab() {
 
       {getOutputDialog()}
 
-      <DiffViewer
+      {/* <DiffViewer
         open={diffViewerOpen}
         onClose={() => setDiffViewerOpen(false)}
         prevBackup={backups[selectedBackup - 1]}
         currentFileContents={code}
         selectedFile={file}
         prevFileContents={prevFileContents}
-      />
+      /> */}
     </Box>
   );
 }


### PR DESCRIPTION
This is an extremely tech-debt-y and messy PR that does the bare minimum to implement the following in the Timeline tab:

- Unified collapsed diff editor by default. If there is no previous diff, then just display a basic file editor
- Be able to jump to the line number where the `# BEGIN Problem XYZ` comments are


https://github.com/user-attachments/assets/16bf5276-a436-40ee-a25d-1e41d4720ee8

